### PR TITLE
Switch auth flow to Supabase

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,12 @@
     "expo-dev-client": "~5.1.8",
     "expo-location": "^18.1.4",
     "expo-system-ui": "~5.0.7",
-    "firebase": "^11.7.1",
     "react": "19.0.0",
     "react-native": "0.79.2",
     "react-native-gesture-handler": "~2.25.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0",
-    "expo-auth-session": "~6.1.5"
+    "react-native-screens": "~4.10.0"
   },
   "devDependencies": {
     "expo-atlas": "^0.4.0",

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,46 +1,39 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { initializeApp } from "firebase/app";
-import {
-  initializeAuth,
-  getReactNativePersistence,
-  onAuthStateChanged,
-  signOut,
-} from "firebase/auth";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-
-const firebaseConfig = {
-  apiKey: "AIzaSyBddXs-09rUAOtVw2Dv0TMsTTINsRwjUGw",
-  authDomain: "trashmap-6b9fa.firebaseapp.com",
-  projectId: "trashmap-6b9fa",
-  storageBucket: "trashmap-6b9fa.appspot.com",
-  messagingSenderId: "526323389961",
-  appId: "1:526323389961:ios:06d4596a6a0e6dca5a0ad8",
-};
-
-const app = initializeApp(firebaseConfig);
-
-const auth = initializeAuth(app, {
-  persistence: getReactNativePersistence(AsyncStorage),
-});
+import { supabase } from "../lib/supabase";
 
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-  const [user, setUser] = useState(null);
+  const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
-      setUser(firebaseUser || null);
+    const init = async () => {
+      const { data } = await supabase.auth.getSession();
+      setSession(data.session);
       setLoading(false);
-    });
-    return unsubscribe;
+    };
+    init();
+
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, newSession) => {
+        setSession(newSession);
+      },
+    );
+
+    return () => {
+      listener.subscription.unsubscribe();
+    };
   }, []);
 
-  const logout = () => signOut(auth);
+  const logout = async () => {
+    await supabase.auth.signOut();
+  };
 
   return (
-    <AuthContext.Provider value={{ user, loading, logout }}>
+    <AuthContext.Provider
+      value={{ user: session?.user || null, session, loading, logout }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/useMateriais.js
+++ b/src/hooks/useMateriais.js
@@ -11,7 +11,7 @@ export const useMateriais = () => {
         .from("materials")
         .select("*")
         .order("created_at", { ascending: true });
-        
+
       const getTextColor = (bgColor) => {
         if (!bgColor || !bgColor.startsWith("#")) return "#000";
         const color = bgColor.replace("#", "");

--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -49,14 +49,7 @@ const TabNavigator = () => {
             } else if (route.name === "Perfil") {
               iconName = focused ? "person" : "person-outline";
             } else if (route.name === "Adicionar") {
-              return (
-                <Ionicons
-                  name="add"
-                  size={36}
-                  color="#fff"
-                  style={{}}
-                />
-              );
+              return <Ionicons name="add" size={36} color="#fff" style={{}} />;
             }
             return <Ionicons name={iconName} size={size} color={color} />;
           },

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -26,7 +26,9 @@ const HomeScreen = () => {
   const cardColor = isDarkMode ? "#1a1a1a" : "#f2f2f2";
 
   const { user } = useAuth();
-  const firstName = user?.displayName?.split(" ")[0] || "reciclador";
+  const fullName =
+    user?.user_metadata?.full_name || user?.email || "reciclador";
+  const firstName = fullName.split(" ")[0];
 
   // ↔️  Cache states
   const [materiaisData, setMateriaisData] = useState([]);
@@ -57,7 +59,7 @@ const HomeScreen = () => {
     if (!loadingMateriais && materiais.length) {
       setMateriaisData(materiais);
       AsyncStorage.setItem("materiais_cache", JSON.stringify(materiais)).catch(
-        console.warn
+        console.warn,
       );
     }
   }, [loadingMateriais, materiais]);

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,37 +1,35 @@
-import { View, Button } from "react-native";
-import {
-  GoogleAuthProvider,
-  signInWithCredential,
-  getAuth,
-} from "firebase/auth";
-import * as Google from "expo-auth-session/providers/google";
-import { makeRedirectUri } from "expo-auth-session";
 import { useEffect } from "react";
+import { View, Button } from "react-native";
+import * as WebBrowser from "expo-web-browser";
+import * as Linking from "expo-linking";
+import { supabase } from "../lib/supabase";
+
+WebBrowser.maybeCompleteAuthSession();
 
 export default function LoginScreen() {
-  const redirectUri = makeRedirectUri({
-    native: "com.juanaleixo.trashmap:/oauthredirect",
-  });
+  const redirectTo = Linking.createURL("/auth/callback");
 
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    expoClientId: process.env.EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID,
-    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
-    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
-    redirectUri,
-  });
+  async function signInWithGoogle() {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo },
+    });
+    if (error) return console.error(error);
+
+    await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
+  }
 
   useEffect(() => {
-    if (response?.type === "success") {
-      const { id_token } = response.params;
-      const auth = getAuth();
-      const credential = GoogleAuthProvider.credential(id_token);
-      signInWithCredential(auth, credential).catch(console.error);
-    }
-  }, [response]);
+    const sub = Linking.addEventListener("url", async ({ url }) => {
+      const { error } = await supabase.auth.handleRedirectURL(url);
+      if (error) console.error(error);
+    });
+    return () => sub.remove();
+  }, []);
 
   return (
     <View style={{ flex: 1, justifyContent: "center", padding: 20 }}>
-      <Button title="Entrar com Google" onPress={() => promptAsync()} />
+      <Button title="Entrar com Google" onPress={signInWithGoogle} />
     </View>
   );
 }

--- a/src/screens/MapScreen.js
+++ b/src/screens/MapScreen.js
@@ -119,7 +119,7 @@ export default function MapScreen() {
   const animatedMapStyle = useAnimatedStyle(() => {
     const bottomOffset = Math.max(
       0,
-      SCREEN_HEIGHT - animatedPosition.value - 60 - insets.bottom
+      SCREEN_HEIGHT - animatedPosition.value - 60 - insets.bottom,
     );
     return {
       marginBottom: bottomOffset,

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -35,7 +35,7 @@ const SearchScreen = () => {
 
   const toggleMaterial = (id) => {
     setSelectedMaterials((prev) =>
-      prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id]
+      prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id],
     );
   };
 
@@ -49,7 +49,7 @@ const SearchScreen = () => {
       let query = supabase
         .from("places_with_coordinates")
         .select(
-          "id, name, latitude, longitude, accepted_materials, accepted_materials_id"
+          "id, name, latitude, longitude, accepted_materials, accepted_materials_id",
         )
         .ilike("name", `%${searchText}%`);
 

--- a/src/screens/UserScreen.js
+++ b/src/screens/UserScreen.js
@@ -1,88 +1,75 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Button, ActivityIndicator } from 'react-native';
-import { getAuth } from 'firebase/auth';
-import { useColorScheme } from 'react-native';
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Button,
+  ActivityIndicator,
+} from "react-native";
+import { useColorScheme } from "react-native";
+import { useAuth } from "../context/AuthContext";
 
 export default function UserScreen() {
-    const [user, setUser] = useState(null);
-    const [loading, setLoading] = useState(true);
-    const dynamicStyles = useUserScreenStyles();
+  const { user, loading, logout } = useAuth();
+  const dynamicStyles = useUserScreenStyles();
 
-    useEffect(() => {
-        const auth = getAuth();
-        const unsubscribe = auth.onAuthStateChanged((currentUser) => {
-            setUser(currentUser);
-            setLoading(false);
-        });
-        return unsubscribe;
-    }, []);
-
-    if (loading) {
-        return (
-            <View style={dynamicStyles.container}>
-                <ActivityIndicator size="large" />
-            </View>
-        );
-    }
-
-    if (!user) {
-        return (
-            <View style={dynamicStyles.container}>
-                <Text style={dynamicStyles.text}>Nenhum usuário autenticado.</Text>
-            </View>
-        );
-    }
-
+  if (loading) {
     return (
-        <View style={dynamicStyles.container}>
-            <Text style={dynamicStyles.title}>Usuário</Text>
-            <Text style={dynamicStyles.text}>Nome: {user.displayName || 'Não informado'}</Text>
-            <Text style={dynamicStyles.text}>Email: {user.email || 'Não informado'}</Text>
-            <View style={{ marginTop: 24 }}>
-                <Button
-                    title="Logout"
-                    onPress={async () => {
-                        const auth = getAuth();
-                        try {
-                            await auth.signOut();
-                        } catch (error) {
-                            // Trate o erro se necessário
-                        }
-                    }}
-                />
-            </View>
-        </View>
+      <View style={dynamicStyles.container}>
+        <ActivityIndicator size="large" />
+      </View>
     );
+  }
+
+  if (!user) {
+    return (
+      <View style={dynamicStyles.container}>
+        <Text style={dynamicStyles.text}>Nenhum usuário autenticado.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={dynamicStyles.container}>
+      <Text style={dynamicStyles.title}>Usuário</Text>
+      <Text style={dynamicStyles.text}>
+        Nome: {user.user_metadata?.full_name || "Não informado"}
+      </Text>
+      <Text style={dynamicStyles.text}>
+        Email: {user.email || "Não informado"}
+      </Text>
+      <View style={{ marginTop: 24 }}>
+        <Button title="Logout" onPress={logout} />
+      </View>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#fff', // default light background
-    },
-    title: {
-        fontSize: 24,
-        fontWeight: 'bold',
-        marginBottom: 16,
-        color: '#222', // default light text
-    },
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#fff", // default light background
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 16,
+    color: "#222", // default light text
+  },
 });
 
 export function useUserScreenStyles() {
-    const colorScheme = useColorScheme();
-    return {
-        container: [
-            styles.container,
-            colorScheme === 'dark' && { backgroundColor: '#121212' },
-        ],
-        title: [
-            styles.title,
-            colorScheme === 'dark' && { color: '#fff' },
-        ],
-        text: {
-            color: colorScheme === 'dark' ? '#fff' : '#222',
-        },
-    };
+  const colorScheme = useColorScheme();
+  return {
+    container: [
+      styles.container,
+      colorScheme === "dark" && { backgroundColor: "#121212" },
+    ],
+    title: [styles.title, colorScheme === "dark" && { color: "#fff" }],
+    text: {
+      color: colorScheme === "dark" ? "#fff" : "#222",
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- swap Firebase auth for Supabase auth
- update login screen to use Supabase OAuth
- adjust user profile and home screen to read data from Supabase session
- remove unused Firebase and Expo Auth Session dependencies
- format files with Prettier

## Testing
- `npm run lint:check`

------
https://chatgpt.com/codex/tasks/task_e_6882c96dcd408332afc9afc20347382c