### PR TITLE
Replace Firebase auth with Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We are actively working to launch the first version of TrashMap! Stay tuned for 
 ## 📲 Technologies Used
 
 - React Native
-- Firebase
+- Supabase
 - Expo
 - Geolocation
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "expo-dev-client": "~5.1.8",
     "expo-location": "^18.1.4",
     "expo-system-ui": "~5.0.7",
-    "firebase": "^11.7.1",
     "react": "19.0.0",
     "react-native": "0.79.2",
     "react-native-gesture-handler": "~2.25.0",

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,27 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { initializeApp } from "firebase/app";
-import {
-  initializeAuth,
-  getReactNativePersistence,
-  onAuthStateChanged,
-  signOut,
-} from "firebase/auth";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-
-const firebaseConfig = {
-  apiKey: "AIzaSyBddXs-09rUAOtVw2Dv0TMsTTINsRwjUGw",
-  authDomain: "trashmap-6b9fa.firebaseapp.com",
-  projectId: "trashmap-6b9fa",
-  storageBucket: "trashmap-6b9fa.appspot.com",
-  messagingSenderId: "526323389961",
-  appId: "1:526323389961:ios:06d4596a6a0e6dca5a0ad8",
-};
-
-const app = initializeApp(firebaseConfig);
-
-const auth = initializeAuth(app, {
-  persistence: getReactNativePersistence(AsyncStorage),
-});
+import { supabase } from "../lib/supabase";
 
 const AuthContext = createContext();
 
@@ -30,14 +8,22 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
-      setUser(firebaseUser || null);
+    supabase.auth.getUser().then(({ data, error }) => {
+      if (error) console.error(error);
+      setUser(data?.user ?? null);
       setLoading(false);
     });
-    return unsubscribe;
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription.unsubscribe();
   }, []);
 
-  const logout = () => signOut(auth);
+  const logout = () => supabase.auth.signOut();
 
   return (
     <AuthContext.Provider value={{ user, loading, logout }}>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -26,7 +26,8 @@ const HomeScreen = () => {
   const cardColor = isDarkMode ? "#1a1a1a" : "#f2f2f2";
 
   const { user } = useAuth();
-  const firstName = user?.displayName?.split(" ")[0] || "reciclador";
+  const firstName =
+    user?.user_metadata?.full_name?.split(" ")[0] || "reciclador";
 
   // ↔️  Cache states
   const [materiaisData, setMateriaisData] = useState([]);

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,37 +1,35 @@
-import { View, Button } from "react-native";
-import {
-  GoogleAuthProvider,
-  signInWithCredential,
-  getAuth,
-} from "firebase/auth";
-import * as Google from "expo-auth-session/providers/google";
-import { makeRedirectUri } from "expo-auth-session";
 import { useEffect } from "react";
+import { View, Button } from "react-native";
+import * as WebBrowser from "expo-web-browser";
+import * as Linking from "expo-linking";
+import { supabase } from "../lib/supabase";
+
+WebBrowser.maybeCompleteAuthSession();
 
 export default function LoginScreen() {
-  const redirectUri = makeRedirectUri({
-    native: "com.juanaleixo.trashmap:/oauthredirect",
-  });
+  const redirectTo = Linking.createURL("/auth/callback");
 
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    expoClientId: process.env.EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID,
-    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
-    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
-    redirectUri,
-  });
+  async function signInWithGoogle() {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo },
+    });
+    if (error) return console.error(error);
+
+    await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
+  }
 
   useEffect(() => {
-    if (response?.type === "success") {
-      const { id_token } = response.params;
-      const auth = getAuth();
-      const credential = GoogleAuthProvider.credential(id_token);
-      signInWithCredential(auth, credential).catch(console.error);
-    }
-  }, [response]);
+    const sub = Linking.addEventListener("url", async ({ url }) => {
+      const { error } = await supabase.auth.handleRedirectURL(url);
+      if (error) console.error(error);
+    });
+    return () => sub.remove();
+  }, []);
 
   return (
     <View style={{ flex: 1, justifyContent: "center", padding: 20 }}>
-      <Button title="Entrar com Google" onPress={() => promptAsync()} />
+      <Button title="Entrar com Google" onPress={signInWithGoogle} />
     </View>
   );
 }

--- a/src/screens/UserScreen.js
+++ b/src/screens/UserScreen.js
@@ -1,21 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet, Button, ActivityIndicator } from 'react-native';
-import { getAuth } from 'firebase/auth';
 import { useColorScheme } from 'react-native';
+import { useAuth } from '../context/AuthContext';
 
 export default function UserScreen() {
-    const [user, setUser] = useState(null);
-    const [loading, setLoading] = useState(true);
+    const { user, loading, logout } = useAuth();
     const dynamicStyles = useUserScreenStyles();
-
-    useEffect(() => {
-        const auth = getAuth();
-        const unsubscribe = auth.onAuthStateChanged((currentUser) => {
-            setUser(currentUser);
-            setLoading(false);
-        });
-        return unsubscribe;
-    }, []);
 
     if (loading) {
         return (
@@ -36,19 +26,12 @@ export default function UserScreen() {
     return (
         <View style={dynamicStyles.container}>
             <Text style={dynamicStyles.title}>Usuário</Text>
-            <Text style={dynamicStyles.text}>Nome: {user.displayName || 'Não informado'}</Text>
+            <Text style={dynamicStyles.text}>Nome: {user.user_metadata?.full_name || 'Não informado'}</Text>
             <Text style={dynamicStyles.text}>Email: {user.email || 'Não informado'}</Text>
             <View style={{ marginTop: 24 }}>
                 <Button
                     title="Logout"
-                    onPress={async () => {
-                        const auth = getAuth();
-                        try {
-                            await auth.signOut();
-                        } catch (error) {
-                            // Trate o erro se necessário
-                        }
-                    }}
+                    onPress={logout}
                 />
             </View>
         </View>


### PR DESCRIPTION
## Summary
- remove Firebase dependency and README reference
- use Supabase auth context instead of Firebase
- implement Supabase login screen
- update HomeScreen and UserScreen to use Supabase user metadata

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882c96dcd408332afc9afc20347382c